### PR TITLE
Add storage support for transactions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ find_package(Boost COMPONENTS program_options REQUIRED)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GLOG REQUIRED libglog)
+pkg_check_modules(SQLITE3 REQUIRED sqlite3)
 
 enable_testing()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -std=c++11 -Werror -O2 -Wall -W -D_REENTRANT -fPIC -Wextra")

--- a/src/priv/CMakeLists.txt
+++ b/src/priv/CMakeLists.txt
@@ -42,4 +42,5 @@ target_link_libraries(${TARGET}
     ${Boost_LIBRARIES}
     ${Qt5Core_LIBRARIES}
     ${Qt5Sql_LIBRARIES}
+    ${SQLITE3_LIBRARIES}
 )

--- a/src/priv/com/chancho/book.cpp
+++ b/src/priv/com/chancho/book.cpp
@@ -22,6 +22,7 @@
 
 #include <glog/logging.h>
 
+#include <QDebug>
 #include <QDir>
 #include <QSqlError>
 #include <QSqlQuery>
@@ -31,7 +32,6 @@
 
 #include <com/chancho/system/database_factory.h>
 #include <QtSql/qsqlquerymodel.h>
-#include <QtSql/qsqldriver.h>
 
 #include "book.h"
 
@@ -40,29 +40,82 @@ namespace com {
 namespace chancho {
 
 namespace {
-    const double PRECISION = 100.0;
     const QString DATABASE_NAME = "chancho.db";
     const QString ACCOUNTS_TABLE = "CREATE TABLE IF NOT EXISTS Accounts("\
         "uuid VARCHAR(40) PRIMARY KEY, "\
         "name TEXT NOT NULL,"\
-        "memo TEXT NOT NULL,"\
-        "amount INT)";
+        "memo TEXT,"\
+        "amount TEXT)";  // amounts are stored in text so that we can use the most precise number
     const QString CATEGORIES_TABLE = "CREATE TABLE IF NOT EXISTS Categories("\
         "uuid VARCHAR(40) PRIMARY KEY, "\
         "parent VARCHAR(40), "\
         "name TEXT NOT NULL,"\
         "type INT,"\
         "FOREIGN KEY(parent) REFERENCES Categories(uuid))";
+    const QString TRANSACTION_TABLE = "CREATE TABLE IF NOT EXISTS Transactions("\
+        "uuid VARCHAR(40) PRIMARY KEY, "\
+        "amount TEXT,"\
+        "account VARCHAR(40) NOT NULL, "\
+        "category VARCHAR(40) NOT NULL, "\
+        "day INT, "\
+        "month INT, "\
+        "year INT, "\
+        "contents TEXT, "\
+        "memo TEXT, "\
+        "FOREIGN KEY(account) REFERENCES Accounts(uuid), "\
+        "FOREIGN KEY(category) REFERENCES Categories(uuid))";  // amounts are stored in text so that we can used the most precise number
+    const QString TRANSACTION_INSERT_TRIGGER = "CREATE TRIGGER UpdateAccountAmountOnTransactionInsert AFTER INSERT ON Transactions "\
+        "BEGIN "\
+        "UPDATE Accounts SET amount=AddStringNumbers(amount, new.amount) WHERE uuid=new.account; "\
+        "END";  // AddStringNumbers is an extension added by the application to the db
+    const QString TRANSACTION_UPDATE_TRIGGER = "CREATE TRIGGER UpdateAccountAmountOnTransactionUpdate AFTER UPDATE ON Transactions "\
+        "BEGIN "\
+        "UPDATE Accounts SET amount=AddStringNumbers(SubtractStringNumbers(amount, old.amount), new.amount) WHERE uuid=new.account; "\
+        "END";
+    const QString TRANSACTION_DELETE_TRIGGER = "CREATE TRIGGER UpdateAccountAmountOnTransactionDelete AFTER DELETE ON Transactions "\
+        "BEGIN "\
+        "UPDATE Accounts SET amount=SubtractStringNumbers(amount, old.amount) WHERE uuid=old.account; "\
+        "END";
+    const QString ACCOUNT_DELETE_TRIGGER = "CREATE TRIGGER DeleteTransactionsOnAccountDelete BEFORE DELETE ON Accounts "\
+        "BEGIN "\
+        "DELETE FROM Transactions WHERE account=old.uuid; "\
+        "END";
+    const QString TRANSACTION_MONTH_INDEX = "CREATE INDEX transaction_month_index ON Transactions(year, month);";
+    const QString TRANSACTION_CATEGORY_INDEX = "CREATE INDEX transaction_category_index ON Transactions(category);";
+    const QString TRANSACTION_CATEGORY_MONTH_INDEX = "CREATE INDEX transaction_category_month_index ON Transactions(category, year, month);";
+    const QString TRANSACTION_ACCOUNT_INDEX = "CREATE INDEX transaction_account_index ON Transactions(account);";
     const QString INSERT_UPDATE_ACCOUNT = "INSERT OR REPLACE INTO Accounts(uuid, name, memo, amount) " \
-            "VALUES (:uuid, :name, :memo, :amount)";
+        "VALUES (:uuid, :name, :memo, :amount)";
     const QString INSERT_UPDATE_CATEGORY = "INSERT OR REPLACE INTO Categories(uuid, parent, name, type) " \
-            "VALUES (:uuid, :parent, :name, :type)";
+        "VALUES (:uuid, :parent, :name, :type)";
+    const QString INSERT_TRANSACTION = "INSERT INTO Transactions(uuid, amount, account, category, "\
+        "day, month, year, contents, memo) VALUES (:uuid, :amount, :account, :category, :day, :month, :year, :contents, :memo)";
+    const QString UPDATE_TRANSACTION = "UPDATE Transactions SET amount=:amount, account=:account, category=:category, "\
+        "day=:day, month=:month, year=:year, contents=:contents, memo=:memo WHERE uuid=:uuid";
     const QString DELETE_ACCOUNT = "DELETE FROM Accounts WHERE uuid=:uuid";
     const QString DELETE_CHILD_CATEGORIES = "DELETE FROM Categories WHERE parent=:uuid";
     const QString DELETE_CATEGORY = "DELETE FROM Categories WHERE uuid=:uuid";
-    const QString SELECT_ALL_ACCOUNTS = "SELECT uuid, name, memo, amount FROM Accounts";
-    const QString SELECT_ALL_CATEGORIES = "SELECT uuid, parent, name, type FROM Categories";
+    const QString DELETE_TRANSACTION = "DELETE FROM Transactions WHERE uuid=:uuid";
+    const QString SELECT_ALL_ACCOUNTS = "SELECT uuid, name, memo, amount FROM Accounts ORDER BY name ASC";
+    const QString SELECT_ALL_CATEGORIES = "SELECT uuid, parent, name, type FROM Categories ORDER BY name ASC";
+    const QString SELECT_TRANSACTIONS_MONTH = "SELECT t.uuid, t.amount, t.account, t.category, t.day, t.month, "\
+        "t.year, t.contents, t.memo, c.parent, c.name, c.type, a.name, a.memo, a.amount FROM Transactions AS t "\
+        "INNER JOIN Categories AS c ON t.category = c.uuid INNER JOIN Accounts AS a ON t.account = a.uuid "\
+        "WHERE t.month=:month AND t.year=:year ORDER BY t.year, t.month";
+    const QString SELECT_TRANSACTIONS_CATEGORY = "SELECT t.uuid, t.amount, t.account, t.category, t.day, t.month, "\
+        "t.year, t.contents, t.memo, c.parent, c.name, c.type, a.name, a.memo, a.amount FROM Transactions AS t "\
+        "INNER JOIN Categories AS c ON t.category = c.uuid INNER JOIN Accounts AS a ON t.account = a.uuid "\
+        "WHERE t.category=:category ORDER BY t.year, t.month";
+    const QString SELECT_TRANSACTIONS_CATEGORY_MONTH = "SELECT t.uuid, t.amount, t.account, t.category, t.day, t.month, "\
+        "t.year, t.contents, t.memo, c.parent, c.name, c.type, a.name, a.memo, a.amount FROM Transactions AS t "\
+        "INNER JOIN Categories AS c ON t.category = c.uuid INNER JOIN Accounts AS a ON t.account = a.uuid "\
+        "WHERE t.category=:category AND t.month=:month AND t.year=:year ORDER BY t.year, t.month";
+    const QString SELECT_TRANSACTIONS_ACCOUNT = "SELECT t.uuid, t.amount, t.account, t.category, t.day, t.month, "\
+        "t.year, t.contents, t.memo, c.parent, c.name, c.type, a.name, a.memo, a.amount FROM Transactions AS t "\
+        "INNER JOIN Categories AS c ON t.category = c.uuid INNER JOIN Accounts AS a ON t.account = a.uuid "\
+        "WHERE t.account=:account ORDER BY t.year, t.month";
     const QString FOREIGN_KEY_SUPPORT = "PRAGMA foreign_keys = ON";
+
 }
 
 double Book::DB_VERSION = 0.1;
@@ -127,9 +180,18 @@ Book::initDatabse() {
         // create the required tables and indexes
         bool success = true;
         auto query = db->createQuery();
+        success &= query->exec(FOREIGN_KEY_SUPPORT);
         success &= query->exec(ACCOUNTS_TABLE);
         success &= query->exec(CATEGORIES_TABLE);
-        success &= query->exec(FOREIGN_KEY_SUPPORT);
+        success &= query->exec(TRANSACTION_TABLE);
+        success &= query->exec(TRANSACTION_INSERT_TRIGGER);
+        success &= query->exec(TRANSACTION_UPDATE_TRIGGER);
+        success &= query->exec(TRANSACTION_DELETE_TRIGGER);
+        success &= query->exec(ACCOUNT_DELETE_TRIGGER);
+        success &= query->exec(TRANSACTION_MONTH_INDEX);
+        success &= query->exec(TRANSACTION_CATEGORY_INDEX);
+        success &= query->exec(TRANSACTION_CATEGORY_MONTH_INDEX);
+        success &= query->exec(TRANSACTION_ACCOUNT_INDEX);
 
         if (success)
             db->commit();
@@ -174,16 +236,14 @@ Book::store(AccountPtr acc) {
     query->bindValue(":name", acc->name);
     query->bindValue(":memo", acc->memo);
 
-    auto rounded = acc->amount * PRECISION;
-    auto converted = ceil(rounded);
-    LOG(INFO) << "Amount converted from " << acc->amount << " to " << converted;
-    query->bindValue(":amount", converted);
+    query->bindValue(":amount", QString::number(acc->amount));
 
     // no need to use a transaction since is a single insert
     auto success = query->exec();
     if (!success) {
         _lastError = _db->lastError().text();
         LOG(ERROR) << _lastError.toStdString();
+        acc->_dbId = QUuid();
     }
 
     _db->close();
@@ -228,6 +288,75 @@ Book::store(CategoryPtr cat) {
     if (!success) {
         _lastError = _db->lastError().text();
         LOG(ERROR) << _lastError.toStdString();
+        cat->_dbId = QUuid();
+    }
+
+    _db->close();
+}
+
+void
+Book::store(TransactionPtr tran) {
+    // usually accounts and categories must be stored before storing a transactions
+    if (tran->account && !tran->account->wasStoredInDb()) {
+        _lastError = "An account must be stored before adding a transaction to it.";
+        LOG(ERROR) << _lastError.toStdString();
+        return;
+    }
+
+    if (tran->category && !tran->category->wasStoredInDb()) {
+        _lastError = "A category must be stored before adding a transaction to it.";
+        LOG(ERROR) << _lastError.toStdString();
+        return;
+    }
+
+
+    bool opened = _db->open();
+
+    if (!opened) {
+        _lastError = _db->lastError().text();
+        LOG(ERROR) << _lastError.toStdString();
+        return;
+    }
+
+    auto isPresent = tran->wasStoredInDb();
+    if (!isPresent) {
+        tran->_dbId = QUuid::createUuid();
+    }
+
+
+    // with transactions we have to make a diff, since we are using two triggers to update the accounts
+    // table correctly, we cannot use an INSERT OR REPLACE because it will not trigger and update.
+    auto query = _db->createQuery();
+    if (!isPresent) {
+        DLOG(INFO) << "Using insert statement for transaction";
+        query->prepare(INSERT_TRANSACTION);
+    } else {
+        DLOG(INFO) << "Using update statement for transaction";
+        query->prepare(UPDATE_TRANSACTION);
+    }
+    query->bindValue(":uuid", tran->_dbId.toString());
+
+    // amounts are positive yet if it is an expense we must multiple by -1 to update the account accordingly
+    if (tran->type() == Category::Type::EXPENSE && tran->amount > 0) {
+        query->bindValue(":amount", QString::number(-1 * tran->amount));
+    } else {
+        query->bindValue(":amount", QString::number(tran->amount));
+    }
+
+    query->bindValue(":account", tran->account->_dbId.toString());
+    query->bindValue(":category", tran->category->_dbId.toString());
+    query->bindValue(":day", tran->date.day());
+    query->bindValue(":month", tran->date.month());
+    query->bindValue(":year", tran->date.year());
+    query->bindValue(":contents", tran->contents);
+    query->bindValue(":memo", tran->memo);
+
+    // no need to use a transaction since is a single insert
+    auto success = query->exec();
+    if (!success) {
+        _lastError = _db->lastError().text();
+        LOG(INFO) << _lastError.toStdString();
+        tran->_dbId = QUuid();
     }
 
     _db->close();
@@ -309,6 +438,36 @@ Book::remove(CategoryPtr cat) {
     _db->close();
 }
 
+void
+Book::remove(TransactionPtr tran) {
+    if (tran->_dbId.isNull()) {
+        LOG(ERROR) << "Cannot delete transaction with a NULL id";
+        _lastError = "Cannot delete Account that was not added to the db";
+        return;
+    }
+
+    bool opened = _db->open();
+
+    if (!opened) {
+        _lastError = _db->lastError().text();
+        LOG(ERROR) << _lastError.toStdString();
+        return;
+    }
+
+    auto query = _db->createQuery();
+    query->prepare(DELETE_TRANSACTION);
+    query->bindValue(":uuid", tran->_dbId.toString());
+    auto success = query->exec();
+
+    if (!success) {
+        _lastError = _db->lastError().text();
+        LOG(ERROR) << _lastError.toStdString();
+    }
+
+    tran->_dbId = QUuid();
+
+    _db->close();
+}
 
 QList<AccountPtr>
 Book::accounts() {
@@ -323,15 +482,32 @@ Book::accounts() {
     }
 
     auto query = _db->createQuery();
-    query->exec(SELECT_ALL_ACCOUNTS);
+    auto sucess = query->exec(SELECT_ALL_ACCOUNTS);
+    if (!sucess) {
+        _lastError = _db->lastError().text();
+        LOG(INFO) << "Error retrieving the accounts " << _lastError.toStdString();
+        _db->close();
+        return accs;
+    }
 
+    // SELECT_ALL_ACCOUNTS = "SELECT uuid, name, memo, amount FROM Accounts";
+    // therefore:
+    // index 0 => uuid
+    // index 1 => name
+    // index 2 => memo
+    // index 3 => amount
+    // using indexes is more efficient than strings
     while (query->next()) {
-        auto amount = query->value("amount").toInt() / PRECISION;
-        auto current = std::make_shared<Account>(query->value("name").toString(),
-                amount, query->value("memo").toString());
-        current->_dbId = QUuid(query->value("uuid").toString());
+        auto uuid = QUuid(query->value(0).toString());
+        auto name = query->value(1).toString();
+        auto memo = query->value(2).toString();
+        auto amount = query->value(3).toString().toDouble();
+        auto current = std::make_shared<Account>(name, amount, memo);
+        current->_dbId = uuid;
         accs.append(current);
     }
+
+    _db->close();
 
     return accs;
 }
@@ -351,17 +527,36 @@ Book::categories() {
     }
 
     auto query = _db->createQuery();
-    query->exec(SELECT_ALL_CATEGORIES);
+    auto sucess = query->exec(SELECT_ALL_CATEGORIES);
 
+    if (!sucess) {
+        _lastError = _db->lastError().text();
+        LOG(INFO) << "Error retrieving the categories " << _lastError.toStdString();
+        _db->close();
+        QList<CategoryPtr> cats;
+        return cats;
+    }
+
+
+    // SELECT_ALL_CATEGORIES = "SELECT uuid, parent, name, type FROM Categories";
+    // therefore
+    // index 0 => uuid
+    // index 1 => parent
+    // index 2 => name
+    // index 3 => type
+    // is more efficient to use indexes that strings
     while (query->next()) {
-        auto cat = std::make_shared<Category>(query->value("name").toString(),
-                static_cast<Category::Type>(query->value("type").toInt()));
-        cat->_dbId = QUuid(query->value("uuid").toString());
+        auto uuid = QUuid(query->value(0).toString());
+        auto parentVar = query->value(1);
+        auto name = query->value(2).toString();
+        auto type = static_cast<Category::Type>(query->value(3).toInt());
+        auto cat = std::make_shared<Category>(name, type);
+        cat->_dbId = uuid;
         LOG(INFO) << "Category found with id " << cat->_dbId.toString().toStdString();
         catsMap[cat->_dbId] = cat;
 
-        if(!query->value("parent").isNull()) {
-            auto parent = QUuid(query->value("parent").toString());
+        if(!parentVar.isNull()) {
+            auto parent = QUuid(parentVar.toString());
             DLOG(INFO) << "Parent relationship foudn with " << parent.toString().toStdString();
 
             if(parentChildMap.contains(parent)) {
@@ -394,7 +589,199 @@ Book::categories() {
         }
     }
 
+    _db->close();
+
     return catsMap.values();
+}
+
+QList<TransactionPtr>
+Book::parseTransactions(std::shared_ptr<system::Query> query) {
+    QList<TransactionPtr> trans;
+
+    // accounts are categories are usually repeated so we can keep a map to just create them the first time the appear
+    // in the inner join
+    QMap<QUuid, AccountPtr> accounts;
+    QMap<QUuid, CategoryPtr> categories;
+
+    auto success = query->exec();
+    if (!success) {
+        _lastError = _db->lastError().text();
+        LOG(INFO) << "Error retrieving the transactions " << _lastError.toStdString();
+        return trans;
+    }
+
+    while (query->next()) {
+        auto transUuid = QUuid(query->value(0).toString());
+        auto transAmount = query->value(1).toString().toDouble();
+        auto accUuid = QUuid(query->value(2).toString());
+        auto catUuid = QUuid(query->value(3).toString());
+        auto transDay = query->value(4).toInt();
+        auto transMonth = query->value(5).toInt();
+        auto transYear = query->value(6).toInt();
+        auto transContents = query->value(7).toString();
+        auto transMemo = query->value(8).toString();
+
+        CategoryPtr category;
+        if (categories.contains(catUuid)) {
+            category = categories[catUuid];
+        } else {
+            // ignore the parent
+            // auto catParent = query->value(9).toString();
+            auto catName = query->value(10).toString();
+            auto catType = static_cast<Category::Type>(query->value(11).toInt());
+            category = std::make_shared<Category>(catName, catType);
+            category->_dbId = catUuid;
+            // add it to be faster with other transactions with the same category
+            categories[catUuid] = category;
+        }
+
+        AccountPtr account;
+        if (accounts.contains(accUuid)) {
+            account = accounts[accUuid];
+        } else {
+            auto accName = query->value(12).toString();
+            auto accMemo = query->value(13).toString();
+            auto accAmount = query->value(14).toString().toDouble();
+            account = std::make_shared<Account>(accName, accAmount, accMemo);
+            account->_dbId = accUuid;
+            accounts[accUuid] = account;
+        }
+
+        auto transaction = std::make_shared<Transaction>(
+                account, transAmount, category, QDate(transYear, transMonth, transDay), transContents, transMemo);
+        transaction->_dbId = transUuid;
+        trans.append(transaction);
+    }
+    return trans;
+}
+
+QList<TransactionPtr>
+Book::transactions(int moth, int year) {
+    QList<TransactionPtr> trans;
+    bool opened = _db->open();
+
+    if (!opened) {
+        _lastError = _db->lastError().text();
+        LOG(ERROR) << _lastError.toStdString();
+        return trans;
+    }
+
+    // SELECT_TRANSACTIONS_MONTH = "SELECT t.uuid, t.amount, t.account, t.category, t.day, t.month, t.year, t.contents, t.memo,
+    //         c.parent, c.name, c.type, a.name, a.memo, a.amount FROM Transactions AS t
+    //         INNER JOIN Categories AS c ON t.category = c.uuid INNER JOIN Accounts AS a ON t.account = a.uuid
+    //         WHERE t.month=:month AND t.year=:year";
+    auto query = _db->createQuery();
+    query->prepare(SELECT_TRANSACTIONS_MONTH);
+    query->bindValue(":month", moth);
+    query->bindValue(":year", year);
+
+    // executes the query and parses the result
+    trans = parseTransactions(query);
+
+    _db->close();
+
+    return trans;
+}
+
+QList<TransactionPtr>
+Book::transactions(CategoryPtr cat) {
+    QList<TransactionPtr> trans;
+
+    if (!cat->wasStoredInDb()) {
+        LOG(INFO) << "Returning empty list because category was not stored.";
+        return  trans;
+    }
+    bool opened = _db->open();
+
+    if (!opened) {
+        _lastError = _db->lastError().text();
+        LOG(ERROR) << _lastError.toStdString();
+        return trans;
+    }
+
+
+    // SELECT_TRANSACTIONS_CATEGORY = SELECT t.uuid, t.amount, t.account, t.category, t.day, t.month,
+    //    t.year, t.contents, t.memo, c.parent, c.name, c.type, a.name, a.memo, a.amount FROM Transactions AS t
+    //    INNER JOIN Categories AS c ON t.category = c.uuid INNER JOIN Accounts AS a ON t.account = a.uuid
+    //    WHERE t.category=:category;
+    auto query = _db->createQuery();
+    query->prepare(SELECT_TRANSACTIONS_CATEGORY);
+    query->bindValue(":category", cat->_dbId.toString());
+
+    // executes the query and parses the result
+    trans = parseTransactions(query);
+
+    _db->close();
+
+    return trans;
+}
+
+QList<TransactionPtr>
+Book::transactions(CategoryPtr cat, int month, int year) {
+    QList<TransactionPtr> trans;
+
+    if (!cat->wasStoredInDb()) {
+        LOG(INFO) << "Returning empty list because category was not stored.";
+        return  trans;
+    }
+    bool opened = _db->open();
+
+    if (!opened) {
+        _lastError = _db->lastError().text();
+        LOG(ERROR) << _lastError.toStdString();
+        return trans;
+    }
+
+
+    // SELECT_TRANSACTIONS_CATEGORY_MONTH = "SELECT t.uuid, t.amount, t.account, t.category, t.day, t.month,
+    //     t.year, t.contents, t.memo, c.parent, c.name, c.type, a.name, a.memo, a.amount FROM Transactions AS t
+    //     INNER JOIN Categories AS c ON t.category = c.uuid INNER JOIN Accounts AS a ON t.account = a.uuid
+    //     WHERE t.category=:category AND t.month=:month AND t.year=:year
+    auto query = _db->createQuery();
+    query->prepare(SELECT_TRANSACTIONS_CATEGORY_MONTH);
+    query->bindValue(":category", cat->_dbId.toString());
+    query->bindValue(":month", month);
+    query->bindValue(":year", year);
+
+    // executes the query and parses the result
+    trans = parseTransactions(query);
+
+    _db->close();
+
+    return trans;
+}
+
+QList<TransactionPtr>
+Book::transactions(AccountPtr acc) {
+    QList<TransactionPtr> trans;
+
+    if (!acc->wasStoredInDb()) {
+        LOG(INFO) << "Returning empty list because account was not stored.";
+        return  trans;
+    }
+    bool opened = _db->open();
+
+    if (!opened) {
+        _lastError = _db->lastError().text();
+        LOG(ERROR) << _lastError.toStdString();
+        return trans;
+    }
+
+
+    // SELECT_TRANSACTIONS_ACCOUNT = "SELECT t.uuid, t.amount, t.account, t.category, t.day, t.month,
+    //     t.year, t.contents, t.memo, c.parent, c.name, c.type, a.name, a.memo, a.amount FROM Transactions AS t
+    //     INNER JOIN Categories AS c ON t.category = c.uuid INNER JOIN Accounts AS a ON t.account = a.uuid
+    //     WHERE t.account=:account;
+    auto query = _db->createQuery();
+    query->prepare(SELECT_TRANSACTIONS_ACCOUNT);
+    query->bindValue(":account", acc->_dbId.toString());
+
+    // executes the query and parses the result
+    trans = parseTransactions(query);
+
+    _db->close();
+
+    return trans;
 }
 
 bool

--- a/src/priv/com/chancho/book.h
+++ b/src/priv/com/chancho/book.h
@@ -31,6 +31,8 @@
 #include <com/chancho/system/database.h>
 #include "account.h"
 #include "category.h"
+#include "transaction.h"
+
 
 namespace com {
 
@@ -45,10 +47,16 @@ class Book {
 
     virtual void store(AccountPtr acc);
     virtual void store(CategoryPtr cat);
+    virtual void store(TransactionPtr tran);
     virtual void remove(AccountPtr acc);
     virtual void remove(CategoryPtr cat);
+    virtual void remove(TransactionPtr tran);
     virtual QList<AccountPtr> accounts();
     virtual QList<CategoryPtr> categories();
+    virtual QList<TransactionPtr> transactions(int moth, int year);
+    virtual QList<TransactionPtr> transactions(CategoryPtr cat);
+    virtual QList<TransactionPtr> transactions(CategoryPtr cat, int month, int year);
+    virtual QList<TransactionPtr> transactions(AccountPtr acc);
 
     virtual bool isError();
     virtual QString lastError();
@@ -59,6 +67,9 @@ class Book {
     static std::set<QString> TABLES;
     static QString databasePath();
     static void initDatabse();
+
+ private:
+   QList<TransactionPtr> parseTransactions(std::shared_ptr<system::Query> query);
 
  protected:
     std::shared_ptr<system::Database> _db;

--- a/src/priv/com/chancho/system/database.h
+++ b/src/priv/com/chancho/system/database.h
@@ -250,14 +250,14 @@ class Database {
             return false;
         }
 
-        auto added = sqlite3_create_function(handler, "AddStringNumbers", 2, SQLITE_UTF8 | SQLITE_DETERMINISTIC, nullptr, &addStringNumbers, nullptr, nullptr);
+        auto added = sqlite3_create_function(handler, "AddStringNumbers", 2, SQLITE_UTF8, nullptr, &addStringNumbers, nullptr, nullptr);
         if (added == SQLITE_OK) {
             DLOG(INFO) << "AddStringNumbers added";
         } else {
             LOG(WARNING) << "Cannot create SQLite functions: AddStringNumbers";
             return false;
         }
-        added = sqlite3_create_function(handler, "SubtractStringNumbers", 2, SQLITE_UTF8 | SQLITE_DETERMINISTIC, nullptr, &subtractStringNumbers, nullptr, nullptr);
+        added = sqlite3_create_function(handler, "SubtractStringNumbers", 2, SQLITE_UTF8, nullptr, &subtractStringNumbers, nullptr, nullptr);
         if (added == SQLITE_OK) {
             DLOG(INFO) << "SubtractStringNumbers added";
         } else {

--- a/src/priv/com/chancho/transaction.h
+++ b/src/priv/com/chancho/transaction.h
@@ -37,6 +37,8 @@ namespace chancho {
 
 class Transaction {
 
+ friend class Book;
+
  public:
     Transaction() = default;
     Transaction(const AccountPtr& acc,
@@ -71,7 +73,7 @@ class Transaction {
 
 };
 
-typedef std::shared_ptr<Category> TransactionPtr;
+typedef std::shared_ptr<Transaction> TransactionPtr;
 
 }
 

--- a/tests/common/database.h
+++ b/tests/common/database.h
@@ -66,6 +66,7 @@ class MockDatabase : public com::chancho::system::Database {
     MOCK_CONST_METHOD1(tables, QStringList(QSql::TableType type));
     MOCK_METHOD0(transaction, bool());
     MOCK_CONST_METHOD0(userName, QString());
+    MOCK_METHOD0(addSqlite3Extensions, bool());
 };
 
 }

--- a/tests/common/public_account.h
+++ b/tests/common/public_account.h
@@ -32,3 +32,7 @@ class PublicAccount : public com::chancho::Account {
 
     using com::chancho::Account::_dbId;
 };
+
+typedef std::shared_ptr<PublicAccount> PublicAccountPtr;
+
+Q_DECLARE_METATYPE(std::shared_ptr<PublicAccount>)

--- a/tests/common/public_transaction.h
+++ b/tests/common/public_transaction.h
@@ -50,3 +50,5 @@ class PublicTransaction : public chancho::Transaction {
 
     using chancho::Transaction::_dbId;
 };
+
+Q_DECLARE_METATYPE(std::shared_ptr<PublicTransaction>)

--- a/tests/priv/CMakeLists.txt
+++ b/tests/priv/CMakeLists.txt
@@ -4,6 +4,7 @@ set(PRIVATE_TESTS
     test_book_account
     test_book_category
     test_book_mocked
+    test_book_transaction
     test_category
     test_transaction
 )

--- a/tests/priv/test_book.cpp
+++ b/tests/priv/test_book.cpp
@@ -62,7 +62,7 @@ TestBook::testInitDatabase() {
 
     // once the db has been created we need to check that it has the correct version and the required tables
     auto tables = db->tables();
-    QCOMPARE(tables.count(), 2);
+    QCOMPARE(tables.count(), 3);
     QVERIFY(tables.contains("Accounts", Qt::CaseInsensitive));
     QVERIFY(tables.contains("Categories", Qt::CaseInsensitive));
     db->close();
@@ -93,7 +93,7 @@ TestBook::testInitDatabaseNoPresentTables() {
 
     // once the db has been created we need to check that it has the correct version and the required tables
     auto tables = db->tables();
-    QCOMPARE(tables.count(), 2);
+    QCOMPARE(tables.count(), 3);
     QVERIFY(tables.contains("Accounts", Qt::CaseInsensitive));
     QVERIFY(tables.contains("Categories", Qt::CaseInsensitive));
     db->close();
@@ -119,7 +119,7 @@ TestBook::testInitDatabasePresentTables() {
 
     // once the db has been created we need to check that it has the correct version and the required tables
     auto tables = db->tables();
-    QCOMPARE(tables.count(), 2);
+    QCOMPARE(tables.count(), 3);
     QVERIFY(tables.contains("Accounts", Qt::CaseInsensitive));
     QVERIFY(tables.contains("Categories", Qt::CaseInsensitive));
     db->close();

--- a/tests/priv/test_book_account.cpp
+++ b/tests/priv/test_book_account.cpp
@@ -92,7 +92,7 @@ TestBookAccount::testStoreAccount() {
     QVERIFY(success);
     QVERIFY(query->next());
     QCOMPARE(query->value("name").toString(), account->name);
-    QCOMPARE(query->value("amount").toInt(), static_cast<int>(ceil(100.0 * account->amount)));
+    QCOMPARE(query->value("amount").toString(), QString::number(account->amount));
     QCOMPARE(query->value("memo").toString(), account->memo);
 
     db->close();
@@ -150,7 +150,7 @@ TestBookAccount::testUpdateAccount() {
     QVERIFY(success);
     QVERIFY(query->next());
     QCOMPARE(query->value("name").toString(), newName);  // test against new name to be 100% sure
-    QCOMPARE(query->value("amount").toInt(), static_cast<int>(ceil(100.0 * account->amount)));
+    QCOMPARE(query->value("amount").toString(), QString::number(account->amount));
     QCOMPARE(query->value("memo").toString(), newMemo);
 
     db->close();

--- a/tests/priv/test_book_mocked.cpp
+++ b/tests/priv/test_book_mocked.cpp
@@ -32,6 +32,7 @@
 
 #include "matchers.h"
 #include "public_account.h"
+#include "public_transaction.h"
 #include "test_book_mocked.h"
 
 using ::testing::_;
@@ -84,7 +85,7 @@ TestBookMocked::testInitDatbaseMissingTables() {
         .WillOnce(Return(db));
 
     EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
-            .Times(1);
+        .Times(1);
 
     EXPECT_CALL(*db.get(), open())
         .Times(1)
@@ -103,7 +104,7 @@ TestBookMocked::testInitDatbaseMissingTables() {
         .WillOnce(Return(query));
 
     EXPECT_CALL(*query.get(), exec(Matcher<const QString&>(_)))
-        .Times(3)
+        .Times(12)
         .WillRepeatedly(Return(true));
 
     EXPECT_CALL(*db.get(), commit())
@@ -153,7 +154,17 @@ TestBookMocked::testInitDatbaseMissingTablesError() {
         .WillOnce(Return(query));
 
     EXPECT_CALL(*query.get(), exec(Matcher<const QString&>(_)))
-        .Times(3)
+        .Times(12)
+        .WillOnce(Return(true))
+        .WillOnce(Return(true))
+        .WillOnce(Return(true))
+        .WillOnce(Return(true))
+        .WillOnce(Return(true))
+        .WillOnce(Return(true))
+        .WillOnce(Return(true))
+        .WillOnce(Return(true))
+        .WillOnce(Return(true))
+        .WillOnce(Return(true))
         .WillOnce(Return(true))
         .WillOnce(Return(false));
 
@@ -697,6 +708,733 @@ TestBookMocked::testRemoveAccountExecError() {
     book.remove(acc);
     QVERIFY(book.isError());
     QCOMPARE(error.text(), book.lastError());
+
+    // verify expectations
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+    QVERIFY(Mock::VerifyAndClearExpectations(query.get()));
+}
+
+void
+TestBookMocked::testAccountsOpenError() {
+    QSqlError error("Testing driver error", "Text error");
+    auto db = std::make_shared<tests::MockDatabase>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory, addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    PublicBook book;
+
+    auto accounts = book.accounts();
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+    QCOMPARE(accounts.count(), 0);
+
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+}
+
+void
+TestBookMocked::testAccountsExecError() {
+    QSqlError error("Driver error");
+    auto db = std::make_shared<tests::MockDatabase>();
+    auto query = std::make_shared<tests::MockQuery>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory,
+            addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*db.get(), createQuery())
+            .Times(1)
+            .WillOnce(Return(query));
+
+    EXPECT_CALL(*query.get(), exec(_))
+            .Times(1)
+            .WillOnce(Return(false));
+
+    // delete query expectations
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    EXPECT_CALL(*db.get(), close())
+            .Times(1);
+
+    PublicBook book;
+    auto accounts = book.accounts();
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+    QCOMPARE(accounts.count(), 0);
+
+    // verify expectations
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+    QVERIFY(Mock::VerifyAndClearExpectations(query.get()));
+}
+
+void
+TestBookMocked::testCategoriesOpenError() {
+    QSqlError error("Testing driver error", "Text error");
+    auto db = std::make_shared<tests::MockDatabase>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory, addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    PublicBook book;
+
+    auto categories = book.categories();
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+    QCOMPARE(categories.count(), 0);
+
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+}
+
+void
+TestBookMocked::testCategoriesExecError() {
+    QSqlError error("Driver error");
+    auto db = std::make_shared<tests::MockDatabase>();
+    auto query = std::make_shared<tests::MockQuery>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory,
+            addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*db.get(), createQuery())
+            .Times(1)
+            .WillOnce(Return(query));
+
+    EXPECT_CALL(*query.get(), exec(_))
+            .Times(1)
+            .WillOnce(Return(false));
+
+    // delete query expectations
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    EXPECT_CALL(*db.get(), close())
+            .Times(1);
+
+    PublicBook book;
+    auto categories = book.categories();
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+    QCOMPARE(categories.count(), 0);
+
+    // verify expectations
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+    QVERIFY(Mock::VerifyAndClearExpectations(query.get()));
+}
+
+void
+TestBookMocked::testStoreTransactionOpenError() {
+    QSqlError error("Testing driver error", "Text error");
+    auto db = std::make_shared<tests::MockDatabase>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory, addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    auto acc = std::make_shared<PublicAccount>("Bankia", 232.32, "Savings");
+    acc->_dbId = QUuid::createUuid();
+
+    auto cat = std::make_shared<PublicCategory>("Testing cate", chancho::Category::Type::INCOME);
+    cat->_dbId = QUuid::createUuid();
+
+    auto tran = std::make_shared<chancho::Transaction>(acc, 34.4, cat);
+
+    PublicBook book;
+    book.store(tran);
+
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+}
+
+void
+TestBookMocked::testStoreTransactionExecError() {
+    QSqlError error("Driver error");
+    auto db = std::make_shared<tests::MockDatabase>();
+    auto query = std::make_shared<tests::MockQuery>();
+
+    // set db interaction expectations
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory,
+            addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*db.get(), createQuery())
+            .Times(1)
+            .WillOnce(Return(query));
+
+    EXPECT_CALL(*query.get(), prepare(_))
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*query.get(),
+            bindValue(Matcher<const QString&>(_), Matcher<const QVariant&>(_), Matcher<QFlags<QSql::ParamTypeFlag>>(_)))
+            .Times(AnyNumber());
+
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    EXPECT_CALL(*query.get(), exec())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    EXPECT_CALL(*db.get(), close())
+            .Times(1);
+
+    auto acc = std::make_shared<PublicAccount>("Bankia", 232.32, "Savings");
+    acc->_dbId = QUuid::createUuid();
+
+    auto cat = std::make_shared<PublicCategory>("Testing cate", chancho::Category::Type::INCOME);
+    cat->_dbId = QUuid::createUuid();
+
+    auto tran = std::make_shared<chancho::Transaction>(acc, 34.4, cat);
+
+    PublicBook book;
+    book.store(tran);
+
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+
+    // verify expectations
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+    QVERIFY(Mock::VerifyAndClearExpectations(query.get()));
+}
+
+void
+TestBookMocked::testRemoveTransactionOpenError() {
+    QSqlError error("Testing driver error", "Text error");
+    auto db = std::make_shared<tests::MockDatabase>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory, addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    auto acc = std::make_shared<PublicAccount>("Bankia", 232.32, "Savings");
+    acc->_dbId = QUuid::createUuid();
+
+    auto cat = std::make_shared<PublicCategory>("Testing cate", chancho::Category::Type::INCOME);
+    cat->_dbId = QUuid::createUuid();
+
+    auto tran = std::make_shared<PublicTransaction>(acc, 34.4, cat);
+    tran->_dbId = QUuid::createUuid();
+
+    PublicBook book;
+
+    book.remove(tran);
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+    QVERIFY(Mock::VerifyAndClearExpectations(tran.get()));
+}
+
+void
+TestBookMocked::testRemoveTransactionExecError() {
+    QSqlError error("Driver error");
+    auto db = std::make_shared<tests::MockDatabase>();
+    auto query = std::make_shared<tests::MockQuery>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory,
+            addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*db.get(), createQuery())
+            .Times(1)
+            .WillOnce(Return(query));
+
+    EXPECT_CALL(*query.get(), prepare(_))
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*query.get(),
+            bindValue(Matcher<const QString&>(_), Matcher<const QVariant&>(_), Matcher<QFlags<QSql::ParamTypeFlag>>(_)))
+            .Times(AnyNumber());
+
+    EXPECT_CALL(*query.get(), exec())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    // delete query expectations
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    EXPECT_CALL(*db.get(), close())
+            .Times(1);
+
+    auto acc = std::make_shared<PublicAccount>("Bankia", 232.32, "Savings");
+    acc->_dbId = QUuid::createUuid();
+
+    auto cat = std::make_shared<PublicCategory>("Testing cate", chancho::Category::Type::INCOME);
+    cat->_dbId = QUuid::createUuid();
+
+    auto tran = std::make_shared<PublicTransaction>(acc, 34.4, cat);
+    tran->_dbId = QUuid::createUuid();
+
+    PublicBook book;
+    book.remove(tran);
+
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+
+    // verify expectations
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+    QVERIFY(Mock::VerifyAndClearExpectations(query.get()));
+}
+
+void
+TestBookMocked::testTransactionsMonthOpenError() {
+    QSqlError error("Testing driver error", "Text error");
+    auto db = std::make_shared<tests::MockDatabase>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory, addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    PublicBook book;
+    book.transactions(2, 2014);
+
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+}
+
+void
+TestBookMocked::testTransactionsMonthExecError() {
+    QSqlError error("Driver error");
+    auto db = std::make_shared<tests::MockDatabase>();
+    auto query = std::make_shared<tests::MockQuery>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory,
+            addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*db.get(), createQuery())
+            .Times(1)
+            .WillOnce(Return(query));
+
+    EXPECT_CALL(*query.get(), prepare(_))
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*query.get(),
+            bindValue(Matcher<const QString&>(_), Matcher<const QVariant&>(_), Matcher<QFlags<QSql::ParamTypeFlag>>(_)))
+            .Times(AnyNumber());
+
+    EXPECT_CALL(*query.get(), exec())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    // delete query expectations
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    EXPECT_CALL(*db.get(), close())
+            .Times(1);
+
+    PublicBook book;
+    auto trans = book.transactions(2, 2015);
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+    QCOMPARE(trans.count(), 0);
+
+    // verify expectations
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+    QVERIFY(Mock::VerifyAndClearExpectations(query.get()));
+}
+
+void
+TestBookMocked::testTransactionsCategoryOpenError() {
+    QSqlError error("Testing driver error", "Text error");
+    auto db = std::make_shared<tests::MockDatabase>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory, addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    auto cat = std::make_shared<PublicCategory>("Testing cate", chancho::Category::Type::INCOME);
+    cat->_dbId = QUuid::createUuid();
+
+    PublicBook book;
+    book.transactions(cat);
+
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+}
+
+void
+TestBookMocked::testTransactionsCategoryExecError() {
+    QSqlError error("Driver error");
+    auto db = std::make_shared<tests::MockDatabase>();
+    auto query = std::make_shared<tests::MockQuery>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory,
+            addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*db.get(), createQuery())
+            .Times(1)
+            .WillOnce(Return(query));
+
+    EXPECT_CALL(*query.get(), prepare(_))
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*query.get(),
+            bindValue(Matcher<const QString&>(_), Matcher<const QVariant&>(_), Matcher<QFlags<QSql::ParamTypeFlag>>(_)))
+            .Times(AnyNumber());
+
+    EXPECT_CALL(*query.get(), exec())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    // delete query expectations
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    EXPECT_CALL(*db.get(), close())
+            .Times(1);
+
+    auto cat = std::make_shared<PublicCategory>("Testing cate", chancho::Category::Type::INCOME);
+    cat->_dbId = QUuid::createUuid();
+
+    PublicBook book;
+    auto trans = book.transactions(cat);
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+    QCOMPARE(trans.count(), 0);
+
+    // verify expectations
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+    QVERIFY(Mock::VerifyAndClearExpectations(query.get()));
+}
+
+void
+TestBookMocked::testTransactionsCategoryMonthOpenError() {
+    QSqlError error("Testing driver error", "Text error");
+    auto db = std::make_shared<tests::MockDatabase>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory, addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    auto cat = std::make_shared<PublicCategory>("Testing cate", chancho::Category::Type::INCOME);
+    cat->_dbId = QUuid::createUuid();
+
+    PublicBook book;
+    book.transactions(cat, 2, 2015);
+
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+}
+
+void
+TestBookMocked::testTransactionsCategoryMonthExecError() {
+    QSqlError error("Driver error");
+    auto db = std::make_shared<tests::MockDatabase>();
+    auto query = std::make_shared<tests::MockQuery>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory,
+            addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*db.get(), createQuery())
+            .Times(1)
+            .WillOnce(Return(query));
+
+    EXPECT_CALL(*query.get(), prepare(_))
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*query.get(),
+            bindValue(Matcher<const QString&>(_), Matcher<const QVariant&>(_), Matcher<QFlags<QSql::ParamTypeFlag>>(_)))
+            .Times(AnyNumber());
+
+    EXPECT_CALL(*query.get(), exec())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    // delete query expectations
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    EXPECT_CALL(*db.get(), close())
+            .Times(1);
+
+    auto cat = std::make_shared<PublicCategory>("Testing cate", chancho::Category::Type::INCOME);
+    cat->_dbId = QUuid::createUuid();
+
+    PublicBook book;
+    auto trans = book.transactions(cat, 1, 2015);
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+    QCOMPARE(trans.count(), 0);
+
+    // verify expectations
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+    QVERIFY(Mock::VerifyAndClearExpectations(query.get()));
+}
+
+void
+TestBookMocked::testTransactionsAccountOpenError() {
+    QSqlError error("Testing driver error", "Text error");
+    auto db = std::make_shared<tests::MockDatabase>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory, addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    auto acc = std::make_shared<PublicAccount>("Bankia", 232.32, "Savings");
+    acc->_dbId = QUuid::createUuid();
+
+    PublicBook book;
+    book.transactions(acc);
+
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+
+    QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));
+    QVERIFY(Mock::VerifyAndClearExpectations(db.get()));
+}
+
+void
+TestBookMocked::testTransactionsAccountExecError() {
+    QSqlError error("Driver error");
+    auto db = std::make_shared<tests::MockDatabase>();
+    auto query = std::make_shared<tests::MockQuery>();
+
+    // set db interaction expectations
+    EXPECT_CALL(*_dbFactory,
+            addDatabase(Matcher<const QString&>(QStringEqual("QSQLITE")), Matcher<const QString&>(QStringEqual("BOOKS"))))
+            .Times(1)
+            .WillOnce(Return(db));
+
+    EXPECT_CALL(*db.get(), setDatabaseName(QStringEqual(PublicBook::databasePath())))
+            .Times(1);
+
+    EXPECT_CALL(*db.get(), open())
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*db.get(), createQuery())
+            .Times(1)
+            .WillOnce(Return(query));
+
+    EXPECT_CALL(*query.get(), prepare(_))
+            .Times(1)
+            .WillOnce(Return(true));
+
+    EXPECT_CALL(*query.get(),
+            bindValue(Matcher<const QString&>(_), Matcher<const QVariant&>(_), Matcher<QFlags<QSql::ParamTypeFlag>>(_)))
+            .Times(AnyNumber());
+
+    EXPECT_CALL(*query.get(), exec())
+            .Times(1)
+            .WillOnce(Return(false));
+
+    // delete query expectations
+    EXPECT_CALL(*db.get(), lastError())
+            .Times(1)
+            .WillOnce(Return(error));
+
+    EXPECT_CALL(*db.get(), close())
+            .Times(1);
+
+    auto acc = std::make_shared<PublicAccount>("Bankia", 232.32, "Savings");
+    acc->_dbId = QUuid::createUuid();
+
+    PublicBook book;
+    auto trans = book.transactions(acc);
+    QVERIFY(book.isError());
+    QCOMPARE(error.text(), book.lastError());
+    QCOMPARE(trans.count(), 0);
 
     // verify expectations
     QVERIFY(Mock::VerifyAndClearExpectations(_dbFactory));

--- a/tests/priv/test_book_mocked.h
+++ b/tests/priv/test_book_mocked.h
@@ -66,6 +66,30 @@ class TestBookMocked : public BaseTestCase {
     void testRemoveAccountOpenError();
     void testRemoveAccountExecError();
 
+    void testAccountsOpenError();
+    void testAccountsExecError();
+
+    void testCategoriesOpenError();
+    void testCategoriesExecError();
+
+    void testStoreTransactionOpenError();
+    void testStoreTransactionExecError();
+
+    void testRemoveTransactionOpenError();
+    void testRemoveTransactionExecError();
+
+    void testTransactionsMonthOpenError();
+    void testTransactionsMonthExecError();
+
+    void testTransactionsCategoryOpenError();
+    void testTransactionsCategoryExecError();
+
+    void testTransactionsCategoryMonthOpenError();
+    void testTransactionsCategoryMonthExecError();
+
+    void testTransactionsAccountOpenError();
+    void testTransactionsAccountExecError();
+
  private:
     tests::MockDatabaseFactory* _dbFactory;
 };

--- a/tests/priv/test_book_transaction.cpp
+++ b/tests/priv/test_book_transaction.cpp
@@ -1,0 +1,894 @@
+/*
+ * Copyright (c) 2015 Manuel de la Peña <mandel@themacaque.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <QDebug>
+#include <QFileInfo>
+
+#include <com/chancho/system/database.h>
+#include <com/chancho/system/database_factory.h>
+
+#include "public_account.h"
+#include "public_category.h"
+#include "test_book_transaction.h"
+
+namespace sys = com::chancho::system;
+
+namespace {
+    const QString SELECT_TRANSACTION_QUERY =
+            "SELECT amount, account, category, day, month, year, contents, memo FROM Transactions WHERE uuid=:uuid";
+    const QString SELECT_ACCOUNT_QUERY = "SELECT name, amount, memo FROM Accounts WHERE uuid=:uuid";
+}
+
+void
+TestBookTransaction::init() {
+    BaseTestCase::init();
+    PublicBook::initDatabse();
+}
+
+void
+TestBookTransaction::cleanup() {
+    BaseTestCase::cleanup();
+
+    auto dbPath = PublicBook::databasePath();
+    QFileInfo fi(dbPath);
+    if (fi.exists())
+        removeDir(fi.absolutePath());
+}
+
+void
+TestBookTransaction::testStoreTransaction_data() {
+    QTest::addColumn<PublicAccountPtr>("account");
+    QTest::addColumn<double>("amount");
+    QTest::addColumn<PublicCategoryPtr>("category");
+    QTest::addColumn<QDate>("date");
+    QTest::addColumn<QString>("contents");
+    QTest::addColumn<QString>("memo");
+
+    auto account = std::make_shared<PublicAccount>("BBVA", 23.45);
+    auto incomeCategory = std::make_shared<PublicCategory>("Salary", chancho::Category::Type::INCOME);
+    auto expenseCategory = std::make_shared<PublicCategory>("Food", chancho::Category::Type::EXPENSE);
+
+    QTest::newRow("income-obj") << account << 2000.23 << incomeCategory
+            << QDate::fromString("1999-10-15", "yyyy-MM-dd") << "Canonical salary" << "August";
+    QTest::newRow("expense-obj") << account << 200.0 << expenseCategory
+            << QDate::fromString("2000-10-15", "yyyy-MM-dd") << "Streetxo dinner" << "";
+}
+
+void
+TestBookTransaction::testStoreTransaction() {
+    QFETCH(PublicAccountPtr, account);
+    QFETCH(double, amount);
+    QFETCH(PublicCategoryPtr, category);
+    QFETCH(QDate, date);
+    QFETCH(QString, contents);
+    QFETCH(QString, memo);
+
+    PublicBook book;
+
+    book.store(account);
+    QVERIFY(account->wasStoredInDb());
+
+    book.store(category);
+    QVERIFY(category->wasStoredInDb());
+
+    auto transaction = std::make_shared<PublicTransaction>(account, amount, category, date, contents, memo);
+    book.store(transaction);
+
+    QVERIFY(transaction->wasStoredInDb());
+
+    // assert that the db is present in the db
+    auto dbPath = PublicBook::databasePath();
+
+    auto db = sys::DatabaseFactory::instance()->addDatabase("QSQLITE", QTest::currentTestFunction());
+    db->setDatabaseName(dbPath);
+
+    auto opened = db->open();
+    QVERIFY(opened);
+
+    // create the required tables and indexes
+    auto query = db->createQuery();
+    query->prepare(SELECT_TRANSACTION_QUERY);
+    query->bindValue(":uuid", transaction->_dbId.toString());
+    auto success = query->exec();
+
+    QVERIFY(success);
+    QVERIFY(query->next());
+    QCOMPARE(query->value("account").toString(), account->_dbId.toString());
+    if (transaction->type() == chancho::Category::Type::EXPENSE && amount > 0) {
+        QCOMPARE(query->value("amount").toString(), QString::number(-1 * amount));
+    } else {
+        QCOMPARE(query->value("amount").toString(), QString::number(amount));
+    }
+    QCOMPARE(query->value("category").toString(), category->_dbId.toString());
+    QCOMPARE(query->value("day").toInt(), date.day());
+    QCOMPARE(query->value("month").toInt(), date.month());
+    QCOMPARE(query->value("year").toInt(), date.year());
+    QCOMPARE(query->value("contents").toString(), contents);
+    QCOMPARE(query->value("memo").toString(), memo);
+
+    // do assert that the account was updated
+    query->prepare(SELECT_ACCOUNT_QUERY);
+    query->bindValue(":uuid", account->_dbId.toString());
+    success = query->exec();
+
+    QVERIFY(success);
+    QVERIFY(query->next());
+    QCOMPARE(query->value("name").toString(), account->name);
+    if (category->type == chancho::Category::Type::EXPENSE) {
+        QCOMPARE(query->value("amount").toString(), QString::number(account->amount - transaction->amount));
+    } else {
+        QCOMPARE(query->value("amount").toString(), QString::number(account->amount + transaction->amount));
+    }
+    QCOMPARE(query->value("memo").toString(), account->memo);
+
+    db->close();
+}
+
+void
+TestBookTransaction::testUpdateTransaction_data() {
+    QTest::addColumn<PublicAccountPtr>("account");
+    QTest::addColumn<double>("amount");
+    QTest::addColumn<double>("newAmount");
+    QTest::addColumn<PublicCategoryPtr>("category");
+    QTest::addColumn<QDate>("date");
+    QTest::addColumn<QString>("contents");
+    QTest::addColumn<QString>("memo");
+
+    auto account = std::make_shared<PublicAccount>("BBVA", 23.45);
+    auto incomeCategory = std::make_shared<PublicCategory>("Salary", chancho::Category::Type::INCOME);
+    auto expenseCategory = std::make_shared<PublicCategory>("Food", chancho::Category::Type::EXPENSE);
+
+    QTest::newRow("income-obj") << account << 2000.23 << 2.23 << incomeCategory
+            << QDate::fromString("1999-10-15", "yyyy-MM-dd") << "Canonical salary" << "August";
+    QTest::newRow("expense-obj") << account << 200.0 << 100.0 << expenseCategory
+            << QDate::fromString("2000-10-15", "yyyy-MM-dd") << "Streetxo dinner" << "";
+}
+
+void
+TestBookTransaction::testUpdateTransaction() {
+    QFETCH(PublicAccountPtr, account);
+    QFETCH(double, amount);
+    QFETCH(double, newAmount);
+    QFETCH(PublicCategoryPtr, category);
+    QFETCH(QDate, date);
+    QFETCH(QString, contents);
+    QFETCH(QString, memo);
+
+    PublicBook book;
+
+    book.store(account);
+    QVERIFY(account->wasStoredInDb());
+
+    book.store(category);
+    QVERIFY(category->wasStoredInDb());
+
+    auto transaction = std::make_shared<PublicTransaction>(account, amount, category, date, contents, memo);
+    book.store(transaction);
+
+    // update the amount of the transaction and store it again
+    transaction->amount = newAmount;
+    book.store(transaction);
+
+    QVERIFY(transaction->wasStoredInDb());
+
+    // assert that the db is present in the db
+    auto dbPath = PublicBook::databasePath();
+
+    auto db = sys::DatabaseFactory::instance()->addDatabase("QSQLITE", QTest::currentTestFunction());
+    db->setDatabaseName(dbPath);
+
+    auto opened = db->open();
+    QVERIFY(opened);
+
+    // create the required tables and indexes
+    auto query = db->createQuery();
+    query->prepare(SELECT_TRANSACTION_QUERY);
+    query->bindValue(":uuid", transaction->_dbId.toString());
+    auto success = query->exec();
+
+    QVERIFY(success);
+    QVERIFY(query->next());
+    QCOMPARE(query->value("account").toString(), account->_dbId.toString());
+    if (transaction->type() == chancho::Category::Type::EXPENSE && amount > 0) {
+        QCOMPARE(query->value("amount").toString(), QString::number(-1 * newAmount));
+    } else {
+        QCOMPARE(query->value("amount").toString(), QString::number(newAmount));
+    }
+    QCOMPARE(query->value("category").toString(), category->_dbId.toString());
+    QCOMPARE(query->value("day").toInt(), date.day());
+    QCOMPARE(query->value("month").toInt(), date.month());
+    QCOMPARE(query->value("year").toInt(), date.year());
+    QCOMPARE(query->value("contents").toString(), contents);
+    QCOMPARE(query->value("memo").toString(), memo);
+
+    // do assert that the account was updated
+    query->prepare(SELECT_ACCOUNT_QUERY);
+    query->bindValue(":uuid", account->_dbId.toString());
+    success = query->exec();
+
+    QVERIFY(success);
+    QVERIFY(query->next());
+    QCOMPARE(query->value("name").toString(), account->name);
+    if (category->type == chancho::Category::Type::EXPENSE) {
+        QCOMPARE(query->value("amount").toString(), QString::number(account->amount - newAmount));
+    } else {
+        QCOMPARE(query->value("amount").toString(), QString::number(account->amount + newAmount));
+    }
+    QCOMPARE(query->value("memo").toString(), account->memo);
+
+    db->close();
+}
+
+void
+TestBookTransaction::testStoreTransactionNoAccount() {
+    auto acc = std::make_shared<chancho::Account>("Bankia", 89.2, "My savings");
+    auto cat = std::make_shared<PublicCategory>("Food", chancho::Category::Type::EXPENSE);
+    auto transaction = std::make_shared<PublicTransaction>(acc, 87.2, cat, QDate::currentDate(), QString(), QString());
+    PublicBook book;
+    // do not store the acc
+    book.store(cat);
+    book.store(transaction);
+
+    QVERIFY(book.isError());
+}
+
+void
+TestBookTransaction::testStoreTransactionNoCategory() {
+    auto acc = std::make_shared<chancho::Account>("Bankia", 89.2, "My savings");
+    auto cat = std::make_shared<PublicCategory>("Food", chancho::Category::Type::EXPENSE);
+    auto transaction = std::make_shared<PublicTransaction>(acc, 87.2, cat, QDate::currentDate(), QString(), QString());
+    PublicBook book;
+    book.store(acc);
+    // do not store the cat
+    book.store(transaction);
+
+    QVERIFY(book.isError());
+}
+
+void
+TestBookTransaction::testRemoveTransaction_data() {
+    QTest::addColumn<PublicAccountPtr>("account");
+    QTest::addColumn<double>("amount");
+    QTest::addColumn<PublicCategoryPtr>("category");
+    QTest::addColumn<QDate>("date");
+    QTest::addColumn<QString>("contents");
+    QTest::addColumn<QString>("memo");
+
+    auto account = std::make_shared<PublicAccount>("BBVA", 23.45);
+    auto incomeCategory = std::make_shared<PublicCategory>("Salary", chancho::Category::Type::INCOME);
+    auto expenseCategory = std::make_shared<PublicCategory>("Food", chancho::Category::Type::EXPENSE);
+
+    QTest::newRow("income-obj") << account << 2000.23 << incomeCategory
+            << QDate::fromString("1999-10-15", "yyyy-MM-dd") << "Canonical salary" << "August";
+    QTest::newRow("expense-obj") << account << 200.0 << expenseCategory
+            << QDate::fromString("2000-10-15", "yyyy-MM-dd") << "Streetxo dinner" << "";
+}
+
+void
+TestBookTransaction::testRemoveTransaction() {
+    QFETCH(PublicAccountPtr, account);
+    QFETCH(double, amount);
+    QFETCH(PublicCategoryPtr, category);
+    QFETCH(QDate, date);
+    QFETCH(QString, contents);
+    QFETCH(QString, memo);
+
+    PublicBook book;
+
+    book.store(account);
+    QVERIFY(account->wasStoredInDb());
+
+    book.store(category);
+    QVERIFY(category->wasStoredInDb());
+
+    auto transaction = std::make_shared<PublicTransaction>(account, amount, category, date, contents, memo);
+    book.store(transaction);
+
+    QVERIFY(transaction->wasStoredInDb());
+
+    // assert that the db is present in the db
+    auto dbPath = PublicBook::databasePath();
+
+    auto db = sys::DatabaseFactory::instance()->addDatabase("QSQLITE", QTest::currentTestFunction());
+    db->setDatabaseName(dbPath);
+
+    auto opened = db->open();
+    QVERIFY(opened);
+
+    // create the required tables and indexes
+    auto query = db->createQuery();
+    query->prepare(SELECT_TRANSACTION_QUERY);
+    query->bindValue(":uuid", transaction->_dbId.toString());
+    auto success = query->exec();
+
+    QVERIFY(success);
+    QVERIFY(query->next());
+    QCOMPARE(query->value("account").toString(), account->_dbId.toString());
+    if (transaction->type() == chancho::Category::Type::EXPENSE && amount > 0) {
+        QCOMPARE(query->value("amount").toString(), QString::number(-1 * amount));
+    } else {
+        QCOMPARE(query->value("amount").toString(), QString::number(amount));
+    }
+    QCOMPARE(query->value("category").toString(), category->_dbId.toString());
+    QCOMPARE(query->value("day").toInt(), date.day());
+    QCOMPARE(query->value("month").toInt(), date.month());
+    QCOMPARE(query->value("year").toInt(), date.year());
+    QCOMPARE(query->value("contents").toString(), contents);
+    QCOMPARE(query->value("memo").toString(), memo);
+
+    // do assert that the account was updated
+    query->prepare(SELECT_ACCOUNT_QUERY);
+    query->bindValue(":uuid", account->_dbId.toString());
+    success = query->exec();
+
+    QVERIFY(success);
+    QVERIFY(query->next());
+    QCOMPARE(query->value("name").toString(), account->name);
+    if (category->type == chancho::Category::Type::EXPENSE) {
+        QCOMPARE(query->value("amount").toString(), QString::number(account->amount - transaction->amount));
+    } else {
+        QCOMPARE(query->value("amount").toString(), QString::number(account->amount + transaction->amount));
+    }
+    QCOMPARE(query->value("memo").toString(), account->memo);
+
+    db->close();
+
+    // delete the transaction and assert that the amount of the account is the expected one, that is with the
+    // transaction being removed
+    book.remove(transaction);
+    QVERIFY(!transaction->wasStoredInDb());
+
+    opened = db->open();
+    QVERIFY(opened);
+
+    query = db->createQuery();
+    query->prepare(SELECT_ACCOUNT_QUERY);
+    query->bindValue(":uuid", account->_dbId.toString());
+    success = query->exec();
+
+    QVERIFY(success);
+    QVERIFY(query->next());
+    QCOMPARE(query->value("name").toString(), account->name);
+    if (category->type == chancho::Category::Type::EXPENSE) {
+        QCOMPARE(query->value("amount").toString(), QString::number(account->amount));
+    } else {
+        QCOMPARE(query->value("amount").toString(), QString::number(account->amount));
+    }
+    QCOMPARE(query->value("memo").toString(), account->memo);
+
+    db->close();
+}
+
+void
+TestBookTransaction::testTransactionsMonth_data() {
+    QTest::addColumn<chancho::AccountPtr>("account");
+    QTest::addColumn<chancho::CategoryPtr>("category");
+    QTest::addColumn<int>("month");
+    QTest::addColumn<int>("year");
+    QTest::addColumn<QList<std::shared_ptr<PublicTransaction>>>("expected");
+    QTest::addColumn<QList<std::shared_ptr<PublicTransaction>>>("all");
+
+    auto account = std::make_shared<chancho::Account>("Bankia", 0);
+    auto category = std::make_shared<chancho::Category>("Food", chancho::Category::Type::EXPENSE);
+
+    QList<std::shared_ptr<PublicTransaction>> firstExpected;
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            account, 100.2, category, QDate(2015, 2, 1), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            account, 23.0, category, QDate(2015, 2, 3), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            account, 25.6, category, QDate(2015, 2, 6), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            account, 90.9, category, QDate(2015, 2, 2), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> secondExpected;
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            account, 40.2, category, QDate(2014, 1, 30), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            account, 10.5, category, QDate(2014, 1, 15), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            account, 90.0, category, QDate(2014, 1, 28), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            account, 32.0, category, QDate(2014, 1, 13), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> thirdExpected;
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            account, 89.4, category, QDate(2014, 8, 20), QUuid::createUuid().toString()));
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            account, 90.2, category, QDate(2014, 8, 12), QUuid::createUuid().toString()));
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            account, 290., category, QDate(2014, 8, 11), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> all;
+    all.append(firstExpected);
+    all.append(secondExpected);
+    all.append(thirdExpected);
+
+    QTest::newRow("feb-2015") << account << category << 2 << 2015 << firstExpected << all;
+    QTest::newRow("jan-2014") << account << category << 1 << 2014 << secondExpected << all;
+    QTest::newRow("august-2014") << account << category << 8 << 2014 << thirdExpected << all;
+
+}
+
+void
+TestBookTransaction::testTransactionsMonth() {
+    typedef QList<std::shared_ptr<PublicTransaction>> TransactionList;
+
+    QFETCH(chancho::AccountPtr, account);
+    QFETCH(chancho::CategoryPtr, category);
+    QFETCH(int, month);
+    QFETCH(int, year);
+    QFETCH(TransactionList, expected);
+    QFETCH(TransactionList, all);
+
+    PublicBook book;
+
+    book.store(account);
+    QVERIFY(!book.isError());
+
+    book.store(category);
+    QVERIFY(!book.isError());
+
+    foreach(const std::shared_ptr<PublicTransaction> tran, all) {
+        if (tran->wasStoredInDb()) {
+            tran->_dbId = QUuid();
+        }
+        book.store(tran);
+        QVERIFY(!book.isError());
+        QVERIFY(tran->wasStoredInDb());
+    }
+
+    // we have stored all books, we perform the query and then assert the results using the expected list
+    auto transactions = book.transactions(month, year);
+    QCOMPARE(transactions.count(), expected.count());
+
+    QStringList expectedList;
+    foreach(const chancho::TransactionPtr tran, expected) {
+        expectedList.append(tran->contents);
+    }
+    foreach(const chancho::TransactionPtr tran, transactions) {
+        QVERIFY(expectedList.contains(tran->contents));
+    }
+}
+
+void
+TestBookTransaction::testTransactionsCategory_data() {
+    QTest::addColumn<chancho::AccountPtr>("account");
+    QTest::addColumn<chancho::CategoryPtr>("category");
+    QTest::addColumn<QList<chancho::CategoryPtr>>("categories");
+    QTest::addColumn<QList<std::shared_ptr<PublicTransaction>>>("expected");
+    QTest::addColumn<QList<std::shared_ptr<PublicTransaction>>>("all");
+
+    auto account = std::make_shared<chancho::Account>("Bankia", 0);
+    auto firstCategory = std::make_shared<chancho::Category>("Food", chancho::Category::Type::EXPENSE);
+    auto secondCategory = std::make_shared<chancho::Category>("Salary", chancho::Category::Type::INCOME);
+    auto thirdCategory = std::make_shared<chancho::Category>("Cinema", chancho::Category::Type::EXPENSE);
+    QList<chancho::CategoryPtr> categories;
+    categories.append(firstCategory);
+    categories.append(secondCategory);
+    categories.append(thirdCategory);
+
+    QList<std::shared_ptr<PublicTransaction>> firstExpected;
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            account, 100.2, firstCategory, QDate(2015, 2, 1), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            account, 23.0, firstCategory, QDate(2015, 2, 3), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            account, 25.6, firstCategory, QDate(2015, 2, 6), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            account, 90.9, firstCategory, QDate(2015, 2, 2), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> secondExpected;
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            account, 40.2, secondCategory, QDate(2014, 1, 30), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            account, 10.5, secondCategory, QDate(2014, 1, 15), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            account, 90.0, secondCategory, QDate(2014, 1, 28), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            account, 32.0, secondCategory, QDate(2014, 1, 13), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> thirdExpected;
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            account, 89.4, thirdCategory, QDate(2014, 8, 20), QUuid::createUuid().toString()));
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            account, 90.2, thirdCategory, QDate(2014, 8, 12), QUuid::createUuid().toString()));
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            account, 290., thirdCategory, QDate(2014, 8, 11), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> all;
+    all.append(firstExpected);
+    all.append(secondExpected);
+    all.append(thirdExpected);
+
+    QTest::newRow("feb-2015") << account << firstCategory << categories << firstExpected << all;
+    QTest::newRow("jan-2014") << account << secondCategory << categories << secondExpected << all;
+    QTest::newRow("august-2014") << account << thirdCategory << categories << thirdExpected << all;
+}
+
+void
+TestBookTransaction::testTransactionsCategory() {
+    typedef QList<std::shared_ptr<PublicTransaction>> TransactionList;
+    typedef QList<chancho::CategoryPtr> CategoriesList;
+
+    QFETCH(chancho::AccountPtr, account);
+    QFETCH(chancho::CategoryPtr, category);
+    QFETCH(CategoriesList, categories);
+    QFETCH(TransactionList, expected);
+    QFETCH(TransactionList, all);
+
+    PublicBook book;
+
+    book.store(account);
+    QVERIFY(!book.isError());
+
+    foreach(const chancho::CategoryPtr cat, categories) {
+        book.store(cat);
+        QVERIFY(!book.isError());
+        QVERIFY(cat->wasStoredInDb());
+    }
+
+    foreach(const std::shared_ptr<PublicTransaction> tran, all) {
+        if (tran->wasStoredInDb()) {
+            tran->_dbId = QUuid();
+        }
+        book.store(tran);
+        QVERIFY(!book.isError());
+        QVERIFY(tran->wasStoredInDb());
+    }
+
+    // we have stored all books, we perform the query and then assert the results using the expected list
+    auto transactions = book.transactions(category);
+    QCOMPARE(transactions.count(), expected.count());
+
+    QStringList expectedList;
+    foreach(const chancho::TransactionPtr tran, expected) {
+        expectedList.append(tran->contents);
+    }
+    foreach(const chancho::TransactionPtr tran, transactions) {
+        QVERIFY(expectedList.contains(tran->contents));
+    }
+}
+
+void
+TestBookTransaction::testTransactionsCategoryAndMonth_data() {
+    QTest::addColumn<chancho::AccountPtr>("account");
+    QTest::addColumn<chancho::CategoryPtr>("category");
+    QTest::addColumn<int>("month");
+    QTest::addColumn<int>("year");
+    QTest::addColumn<QList<chancho::CategoryPtr>>("categories");
+    QTest::addColumn<QList<std::shared_ptr<PublicTransaction>>>("expected");
+    QTest::addColumn<QList<std::shared_ptr<PublicTransaction>>>("all");
+
+    auto account = std::make_shared<chancho::Account>("Bankia", 0);
+    auto firstCategory = std::make_shared<chancho::Category>("Food", chancho::Category::Type::EXPENSE);
+    auto secondCategory = std::make_shared<chancho::Category>("Salary", chancho::Category::Type::INCOME);
+    auto thirdCategory = std::make_shared<chancho::Category>("Cinema", chancho::Category::Type::EXPENSE);
+    QList<chancho::CategoryPtr> categories;
+    categories.append(firstCategory);
+    categories.append(secondCategory);
+    categories.append(thirdCategory);
+
+    QList<std::shared_ptr<PublicTransaction>> firstExpected;
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            account, 100.2, firstCategory, QDate(2015, 2, 1), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            account, 23.0, firstCategory, QDate(2015, 2, 3), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            account, 25.6, firstCategory, QDate(2015, 2, 6), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            account, 90.9, firstCategory, QDate(2015, 2, 2), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> secondExpected;
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            account, 40.2, secondCategory, QDate(2014, 1, 30), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            account, 10.5, secondCategory, QDate(2014, 1, 15), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            account, 90.0, secondCategory, QDate(2014, 1, 28), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            account, 32.0, secondCategory, QDate(2014, 1, 13), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> thirdExpected;
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            account, 89.4, thirdCategory, QDate(2014, 8, 20), QUuid::createUuid().toString()));
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            account, 90.2, thirdCategory, QDate(2014, 8, 12), QUuid::createUuid().toString()));
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            account, 290., thirdCategory, QDate(2014, 8, 11), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> all;
+    all.append(firstExpected);
+    all.append(secondExpected);
+    all.append(thirdExpected);
+    all.append(std::make_shared<PublicTransaction>(
+            account, 100.2, firstCategory, QDate(2014, 2, 1), QUuid::createUuid().toString()));
+    all.append(std::make_shared<PublicTransaction>(
+            account, 23.0, firstCategory, QDate(2015, 1, 3), QUuid::createUuid().toString()));
+    all.append(std::make_shared<PublicTransaction>(
+            account, 25.6, firstCategory, QDate(2017, 2, 6), QUuid::createUuid().toString()));
+    all.append(std::make_shared<PublicTransaction>(
+            account, 90.9, firstCategory, QDate(2015, 10, 2), QUuid::createUuid().toString()));
+    all.append(std::make_shared<PublicTransaction>(
+            account, 40.2, secondCategory, QDate(2014, 2, 30), QUuid::createUuid().toString()));
+    all.append(std::make_shared<PublicTransaction>(
+            account, 10.5, secondCategory, QDate(2015, 2, 15), QUuid::createUuid().toString()));
+    all.append(std::make_shared<PublicTransaction>(
+            account, 90.0, secondCategory, QDate(2014, 8, 28), QUuid::createUuid().toString()));
+    all.append(std::make_shared<PublicTransaction>(
+            account, 32.0, secondCategory, QDate(2014, 3, 13), QUuid::createUuid().toString()));
+    all.append(std::make_shared<PublicTransaction>(
+            account, 89.4, thirdCategory, QDate(2013, 8, 20), QUuid::createUuid().toString()));
+    all.append(std::make_shared<PublicTransaction>(
+            account, 90.2, thirdCategory, QDate(2015, 8, 12), QUuid::createUuid().toString()));
+    all.append(std::make_shared<PublicTransaction>(
+            account, 290., thirdCategory, QDate(2014, 9, 11), QUuid::createUuid().toString()));
+
+    QTest::newRow("feb-2015") << account << firstCategory << 2 << 2015 << categories << firstExpected << all;
+    QTest::newRow("jan-2014") << account << secondCategory << 1 << 2014 << categories << secondExpected << all;
+    QTest::newRow("august-2014") << account << thirdCategory << 8 << 2014 << categories << thirdExpected << all;
+}
+
+void
+TestBookTransaction::testTransactionsCategoryAndMonth() {
+    typedef QList<std::shared_ptr<PublicTransaction>> TransactionList;
+    typedef QList<chancho::CategoryPtr> CategoriesList;
+
+    QFETCH(chancho::AccountPtr, account);
+    QFETCH(chancho::CategoryPtr, category);
+    QFETCH(int, month);
+    QFETCH(int, year);
+    QFETCH(CategoriesList, categories);
+    QFETCH(TransactionList, expected);
+    QFETCH(TransactionList, all);
+
+    PublicBook book;
+
+    book.store(account);
+    QVERIFY(!book.isError());
+
+    foreach(const chancho::CategoryPtr cat, categories) {
+        book.store(cat);
+        QVERIFY(!book.isError());
+        QVERIFY(cat->wasStoredInDb());
+    }
+
+    foreach(const std::shared_ptr<PublicTransaction> tran, all) {
+        if (tran->wasStoredInDb()) {
+            tran->_dbId = QUuid();
+        }
+        book.store(tran);
+        QVERIFY(!book.isError());
+        QVERIFY(tran->wasStoredInDb());
+    }
+
+    // we have stored all books, we perform the query and then assert the results using the expected list
+    auto transactions = book.transactions(category, month, year);
+    QCOMPARE(transactions.count(), expected.count());
+
+    QStringList expectedList;
+    foreach(const chancho::TransactionPtr tran, expected) {
+        expectedList.append(tran->contents);
+    }
+    foreach(const chancho::TransactionPtr tran, transactions) {
+        QVERIFY(expectedList.contains(tran->contents));
+    }
+}
+
+void
+TestBookTransaction::testTransactionsAccount_data() {
+    QTest::addColumn<chancho::AccountPtr>("account");
+    QTest::addColumn<QList<chancho::AccountPtr>>("accounts");
+    QTest::addColumn<chancho::CategoryPtr>("category");
+    QTest::addColumn<QList<std::shared_ptr<PublicTransaction>>>("expected");
+    QTest::addColumn<QList<std::shared_ptr<PublicTransaction>>>("all");
+
+    auto firstAccount = std::make_shared<chancho::Account>("Bankia", 0);
+    auto secondAccount = std::make_shared<chancho::Account>("BBVA", 0);
+    auto thirdAccount = std::make_shared<chancho::Account>("ING", 0);
+    auto category = std::make_shared<chancho::Category>("Food", chancho::Category::Type::EXPENSE);
+
+    QList<chancho::AccountPtr> accounts;
+    accounts.append(firstAccount);
+    accounts.append(secondAccount);
+    accounts.append(thirdAccount);
+
+    QList<std::shared_ptr<PublicTransaction>> firstExpected;
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            firstAccount, 100.2, category, QDate(2015, 2, 1), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            firstAccount, 23.0, category, QDate(2015, 2, 3), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            firstAccount, 25.6, category, QDate(2015, 2, 6), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            firstAccount, 90.9, category, QDate(2015, 2, 2), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> secondExpected;
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            secondAccount, 40.2, category, QDate(2014, 1, 30), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            secondAccount, 10.5, category, QDate(2014, 1, 15), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            secondAccount, 90.0, category, QDate(2014, 1, 28), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            secondAccount, 32.0, category, QDate(2014, 1, 13), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> thirdExpected;
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            thirdAccount, 89.4, category, QDate(2014, 8, 20), QUuid::createUuid().toString()));
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            thirdAccount, 90.2, category, QDate(2014, 8, 12), QUuid::createUuid().toString()));
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            thirdAccount, 290., category, QDate(2014, 8, 11), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> all;
+    all.append(firstExpected);
+    all.append(secondExpected);
+    all.append(thirdExpected);
+
+    QTest::newRow("feb-2015") << firstAccount << accounts << category << firstExpected << all;
+    QTest::newRow("jan-2014") << secondAccount << accounts << category << secondExpected << all;
+    QTest::newRow("august-2014") << thirdAccount << accounts << category << thirdExpected << all;
+}
+
+void
+TestBookTransaction::testTransactionsAccount() {
+    typedef QList<std::shared_ptr<PublicTransaction>> TransactionList;
+    typedef QList<chancho::AccountPtr> AccountsList;
+
+    QFETCH(chancho::AccountPtr, account);
+    QFETCH(AccountsList, accounts);
+    QFETCH(chancho::CategoryPtr, category);
+    QFETCH(TransactionList, expected);
+    QFETCH(TransactionList, all);
+
+    PublicBook book;
+
+    foreach(const chancho::AccountPtr acc, accounts) {
+        book.store(acc);
+        QVERIFY(acc->wasStoredInDb());
+        QVERIFY(!book.isError());
+    }
+
+    book.store(category);
+    QVERIFY(!book.isError());
+    QVERIFY(category->wasStoredInDb());
+
+    foreach(const std::shared_ptr<PublicTransaction> tran, all) {
+        if (tran->wasStoredInDb()) {
+            tran->_dbId = QUuid();
+        }
+        book.store(tran);
+        QVERIFY(!book.isError());
+        QVERIFY(tran->wasStoredInDb());
+    }
+
+    // we have stored all books, we perform the query and then assert the results using the expected list
+    auto transactions = book.transactions(account);
+    QCOMPARE(transactions.count(), expected.count());
+
+    QStringList expectedList;
+    foreach(const chancho::TransactionPtr tran, expected) {
+        expectedList.append(tran->contents);
+    }
+    foreach(const chancho::TransactionPtr tran, transactions) {
+        QVERIFY(expectedList.contains(tran->contents));
+    }
+}
+
+void
+TestBookTransaction::testDeleteAccountTransactions_data() {
+    QTest::addColumn<PublicAccountPtr>("account");
+    QTest::addColumn<QList<PublicAccountPtr>>("accounts");
+    QTest::addColumn<chancho::CategoryPtr>("category");
+    QTest::addColumn<QList<std::shared_ptr<PublicTransaction>>>("all");
+
+    auto firstAccount = std::make_shared<PublicAccount>("Bankia", 0);
+    auto secondAccount = std::make_shared<PublicAccount>("BBVA", 0);
+    auto thirdAccount = std::make_shared<PublicAccount>("ING", 0);
+    auto category = std::make_shared<chancho::Category>("Food", chancho::Category::Type::EXPENSE);
+
+    QList<PublicAccountPtr> accounts;
+    accounts.append(firstAccount);
+    accounts.append(secondAccount);
+    accounts.append(thirdAccount);
+
+    QList<std::shared_ptr<PublicTransaction>> firstExpected;
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            firstAccount, 100.2, category, QDate(2015, 2, 1), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            firstAccount, 23.0, category, QDate(2015, 2, 3), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            firstAccount, 25.6, category, QDate(2015, 2, 6), QUuid::createUuid().toString()));
+    firstExpected.append(std::make_shared<PublicTransaction>(
+            firstAccount, 90.9, category, QDate(2015, 2, 2), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> secondExpected;
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            secondAccount, 40.2, category, QDate(2014, 1, 30), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            secondAccount, 10.5, category, QDate(2014, 1, 15), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            secondAccount, 90.0, category, QDate(2014, 1, 28), QUuid::createUuid().toString()));
+    secondExpected.append(std::make_shared<PublicTransaction>(
+            secondAccount, 32.0, category, QDate(2014, 1, 13), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> thirdExpected;
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            thirdAccount, 89.4, category, QDate(2014, 8, 20), QUuid::createUuid().toString()));
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            thirdAccount, 90.2, category, QDate(2014, 8, 12), QUuid::createUuid().toString()));
+    thirdExpected.append(std::make_shared<PublicTransaction>(
+            thirdAccount, 290., category, QDate(2014, 8, 11), QUuid::createUuid().toString()));
+
+    QList<std::shared_ptr<PublicTransaction>> all;
+    all.append(firstExpected);
+    all.append(secondExpected);
+    all.append(thirdExpected);
+
+    QTest::newRow("feb-2015") << firstAccount << accounts << category << all;
+    QTest::newRow("jan-2014") << secondAccount << accounts << category << all;
+    QTest::newRow("august-2014") << thirdAccount << accounts << category << all;
+}
+
+void
+TestBookTransaction::testDeleteAccountTransactions() {
+    typedef QList<std::shared_ptr<PublicTransaction>> TransactionList;
+    typedef QList<PublicAccountPtr> AccountsList;
+
+    QFETCH(PublicAccountPtr, account);
+    QFETCH(AccountsList, accounts);
+    QFETCH(chancho::CategoryPtr, category);
+    QFETCH(TransactionList, all);
+
+    PublicBook book;
+
+    foreach(const chancho::AccountPtr acc, accounts) {
+        book.store(acc);
+        QVERIFY(acc->wasStoredInDb());
+        QVERIFY(!book.isError());
+    }
+
+    auto oldId = account->_dbId;
+
+    book.store(category);
+    QVERIFY(!book.isError());
+    QVERIFY(category->wasStoredInDb());
+
+    foreach(const std::shared_ptr<PublicTransaction> tran, all) {
+        if (tran->wasStoredInDb()) {
+            tran->_dbId = QUuid();
+        }
+        book.store(tran);
+        QVERIFY(!book.isError());
+        QVERIFY(tran->wasStoredInDb());
+    }
+
+    book.remove(account);
+    account->_dbId = oldId;
+
+    // we have stored all books, we perform the query and then assert the results using the expected list
+    auto transactions = book.transactions(account);
+    QCOMPARE(transactions.count(), 0);
+}
+
+QTEST_MAIN(TestBookTransaction)

--- a/tests/priv/test_book_transaction.h
+++ b/tests/priv/test_book_transaction.h
@@ -22,26 +22,50 @@
 
 #pragma once
 
-#include <com/chancho/category.h>
+#include <com/chancho/book.h>
+
+#include "public_book.h"
+#include "public_transaction.h"
+#include "base_testcase.h"
 
 namespace chancho = com::chancho;
 
-class PublicCategory : public chancho::Category {
+class TestBookTransaction : public BaseTestCase {
+    Q_OBJECT
+
  public:
-    PublicCategory()
-            : chancho::Category() {}
+    explicit TestBookTransaction(QObject *parent = 0)
+            : BaseTestCase("TestBookTransaction", parent) { }
 
-    PublicCategory(const QString& n, Category::Type t)
-            : chancho::Category(n, t) {}
+ private slots:
 
-    PublicCategory(const QString& n, Category::Type t, std::shared_ptr<Category> p)
-            : chancho::Category(n, t, p) {}
+    void init() override;
+    void cleanup() override;
 
-    virtual ~PublicCategory() = default;
+    void testStoreTransaction_data();
+    void testStoreTransaction();
 
-    using chancho::Category::_dbId;
+    void testUpdateTransaction_data();
+    void testUpdateTransaction();
+
+    void testStoreTransactionNoAccount();
+    void testStoreTransactionNoCategory();
+
+    void testRemoveTransaction_data();
+    void testRemoveTransaction();
+
+    void testTransactionsMonth_data();
+    void testTransactionsMonth();
+
+    void testTransactionsCategory_data();
+    void testTransactionsCategory();
+
+    void testTransactionsCategoryAndMonth_data();
+    void testTransactionsCategoryAndMonth();
+
+    void testTransactionsAccount_data();
+    void testTransactionsAccount();
+
+   void testDeleteAccountTransactions_data();
+    void testDeleteAccountTransactions();
 };
-
-typedef std::shared_ptr<PublicCategory> PublicCategoryPtr;
-
-Q_DECLARE_METATYPE(std::shared_ptr<PublicCategory>)


### PR DESCRIPTION
Add support with transactions that will allow a user to store new expenses and income to an account. The account will have its amount updated thanks to triggers.