### PR TITLE
Show a label to let the user know that no results have been found

### DIFF
--- a/src/public/gui/app/qml/components/MainPage.qml
+++ b/src/public/gui/app/qml/components/MainPage.qml
@@ -60,6 +60,20 @@ PageStack {
            property date date: new Date()
            property var monthModel: Book.monthModel(date)
 
+           Connections {
+                target: dateTitle.monthModel
+                onDaysCountChanged: {
+                    var count = dateTitle.monthModel.daysCount
+                    if (count > 0) {
+                        daysList.visible = true;
+                        noResultLabel.visible = false;
+                    } else {
+                        daysList.visible = false;
+                        noResultLabel.visible = true;
+                    }
+                }
+           }
+
            spacing: units.gu(2)
 
            anchors.fill: parent
@@ -104,11 +118,25 @@ PageStack {
                    anchors.margins: units.gu(1)
                    spacing: units.gu(2)
 
+                   visible: dateTitle.monthModel.daysCount > 0
+
                    model: dateTitle.monthModel
                    delegate: BillingPerDay {
                        dayModel: Book.dayModel(model.display.day, model.display.month, model.display.year)
                    }
                }
+
+               Label {
+                    id: noResultLabel
+                    anchors.centerIn: parent
+                    anchors.margins: units.gu(1)
+
+                    text: i18n.tr("No entries were found!")
+
+                    fontSize: "x-large"
+                    visible: dateTitle.monthModel.daysCount <= 0
+               }
+
            }
 
        }

--- a/src/public/gui/lib/com/chancho/qml/models/month.cpp
+++ b/src/public/gui/lib/com/chancho/qml/models/month.cpp
@@ -144,6 +144,9 @@ Month::setMonth(int month) {
         emit monthChanged(month);
         emit dateChanged(_date);
 
+        auto count = getDaysCount();
+        emit daysCountChanged(count);
+
         endResetModel();
     }
 }
@@ -161,6 +164,9 @@ Month::setYear(int year) {
         _date.setDate(year, _date.month(), _date.day());
         emit yearChanged(year);
         emit dateChanged(_date);
+
+        auto count = getDaysCount();
+        emit daysCountChanged(count);
 
         endResetModel();
     }
@@ -189,6 +195,9 @@ Month::setDate(QDate date) {
             emit yearChanged(_date.year());
         }
 
+        auto count = getDaysCount();
+        emit daysCountChanged(count);
+
         endResetModel();
     }
 }
@@ -198,6 +207,8 @@ Month::onTransactionStored(QDate date) {
     // if the transaction was stored in the month of this model, trigger a redraw
     if (_date.month() == date.month() && _date.year() == date.year()) {
         beginResetModel();
+        auto count = getDaysCount();
+        emit daysCountChanged(count);
         endResetModel();
     }
 }
@@ -206,6 +217,8 @@ void
 Month::onTransactionRemoved(QDate date) {
     if (_date.month() == date.month() && _date.year() == date.year()) {
         beginResetModel();
+        auto count = getDaysCount();
+        emit daysCountChanged(count);
         endResetModel();
     }
 }
@@ -218,6 +231,15 @@ Month::onTransactionUpdated(QDate oldDate, QDate newDate) {
         beginResetModel();
         endResetModel();
     }
+}
+
+int
+Month::getDaysCount() const {
+    auto count = _book->numberOfDaysWithTransactions(_date.month(), _date.year());
+    if (_book->isError()) {
+        return 0;
+    }
+    return count;
 }
 
 }

--- a/src/public/gui/lib/com/chancho/qml/models/month.h
+++ b/src/public/gui/lib/com/chancho/qml/models/month.h
@@ -42,6 +42,7 @@ class Month : public QAbstractListModel {
     Q_PROPERTY(int month READ getMonth WRITE setMonth NOTIFY monthChanged)
     Q_PROPERTY(int year READ getYear WRITE setYear NOTIFY yearChanged)
     Q_PROPERTY(QDate date READ getDate WRITE setDate NOTIFY dateChanged)
+    Q_PROPERTY(int daysCount READ getDaysCount NOTIFY daysCountChanged)
 
     friend class com::chancho::qml::Book;
 
@@ -66,6 +67,8 @@ class Month : public QAbstractListModel {
     QDate getDate() const;
     void setDate(QDate date);
 
+    int getDaysCount() const;
+
  protected:
     Month(BookPtr book, QObject* parent = 0);
     Month(int month, int year, BookPtr book, QObject* parent = 0);
@@ -79,6 +82,7 @@ class Month : public QAbstractListModel {
     void monthChanged(int month);
     void yearChanged(int year);
     void dateChanged(QDate date);
+    void daysCountChanged(int count);
 
  private:
     QDate _date;

--- a/tests/public/gui/lib/test_month_model.h
+++ b/tests/public/gui/lib/test_month_model.h
@@ -62,5 +62,8 @@ class TestMonthModel : public BaseTestCase {
 
     void testSetDate_data();
     void testSetDate();
+
+    void testGetCount();
+    void testGetCountBookError();
 };
 


### PR DESCRIPTION
Fix issue #13 by showing some extra info to the user when no results are found. A new signal is added to track day count changes.