### PR TITLE
Set the locale of the double validator to en so that it will always work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ execute_process(
 
 set(CHANCHO_VERSION_MAJOR 0)
 set(CHANCHO_VERSION_MINOR 1)
-set(CHANCHO_VERSION_PATCH 5)
+set(CHANCHO_VERSION_PATCH 6)
 
 #required bin helpers
 find_program(INTLTOOL_MERGE intltool-merge)

--- a/src/public/gui/app/qml/components/AccountForm.qml
+++ b/src/public/gui/app/qml/components/AccountForm.qml
@@ -191,7 +191,10 @@ UbuntuShape {
 
             inputMethodHints: Qt.ImhFormattedNumbersOnly
 
-            validator: DoubleValidator {}
+            validator: DoubleValidator {
+                id: doubleValidator
+                locale: "en"
+            }
 
             placeholderText: i18n.tr("Initial amount")
         }

--- a/src/public/gui/app/qml/components/TransactionForm.qml
+++ b/src/public/gui/app/qml/components/TransactionForm.qml
@@ -172,7 +172,10 @@ UbuntuShape {
                 anchors.right: parent.right
                 inputMethodHints: Qt.ImhFormattedNumbersOnly
 
-                validator: DoubleValidator {}
+                validator: DoubleValidator {
+                    id: doubleValidator
+                    locale: "en"
+                }
 
                 placeholderText: i18n.tr("Amount")
             }

--- a/src/public/gui/app/qml/components/dialogs/WizardNewAccountDialog.qml
+++ b/src/public/gui/app/qml/components/dialogs/WizardNewAccountDialog.qml
@@ -48,11 +48,15 @@ Dialog {
        placeholderText: i18n.tr("Name")
 
     }
+
     TextField {
         id: initialAmountField
 
         inputMethodHints: Qt.ImhFormattedNumbersOnly
-        validator: DoubleValidator {}
+        validator: DoubleValidator {
+            id: doubleValidator
+            locale: "en"
+        }
         placeholderText: i18n.tr("Initial amount")
     }
 


### PR DESCRIPTION
Fix issue #99 by setting the double check to always use en due to a bug in osk.