### PR TITLE
Display amounts in legend of pie chart

### DIFF
--- a/src/public/gui/app/qml/components/CategoryStatsPage.qml
+++ b/src/public/gui/app/qml/components/CategoryStatsPage.qml
@@ -157,7 +157,8 @@ PageStack {
                         legendModel.clear();
                         for(var index=0; index < categories.length; index++) {
                             var category = categories[index];
-                            legendModel.append({"name":category.name, "color":category.color});
+                            var name = category.name + ' (' + percentages.data[index].value.toString() + ')';
+                            legendModel.append({"name":name, "color":category.color});
                         }
                         repaint();
                     }


### PR DESCRIPTION
Display amount in each category in legend of pie chart (Stats page).

Temporary solution while waiting for an up to date version of Chart.js